### PR TITLE
moving the authotp to login function

### DIFF
--- a/Richdotin_Scalper_App.py
+++ b/Richdotin_Scalper_App.py
@@ -18,10 +18,6 @@ from pathlib import Path
 config = configparser.ConfigParser()
 config.read("config.ini")
 
-authotp = pyotp.TOTP(
-    config.get("CRED", "authenticator")
-).now()  # copy the authenticator code here in quote.
-
 start = datetime.now()
 print(start)
 
@@ -182,6 +178,10 @@ def Login():  # Login function get the api login + username and cash margin
     else:
 
         try:
+            authotp = pyotp.TOTP(
+            config.get("CRED", "authenticator")
+            ).now()  # copy the authenticator code here in quote.
+
             # ret = api.login(userid = config.user, password = config.pwd, twoFA=config.factor2, vendor_code=config.vc, api_secret=config.app_key, imei=config.imei)
             ret = api.login(
                 userid=config.get("CRED", "user"),


### PR DESCRIPTION
Moving authotp  inside login function,  when we run the code without adding the creds to config.ini getting error as  " binascii.Error: Non-base32 digit found".  there are 2 ways to to add credentials one direct add it to config.ini or click login the form will show up will input all the cred details and write it to config.ini which is easy way.